### PR TITLE
Fix the workflow not run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
GitHub workflow does not support double quotes.
https://docs.github.com/en/actions/learn-github-actions/expressions#literals