### PR TITLE
Fixed pickup for queued messages. Added handling of basic messages.

### DIFF
--- a/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
@@ -30,6 +30,7 @@ class WalletMainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityWalletMainBinding
     private var credentialProgress: ProgressDialog? = null
     private var proofProgress: ProgressDialog? = null
+    private val TAG = "WalletMainActivity"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -85,6 +86,12 @@ class WalletMainActivity : AppCompatActivity() {
                 }
             }
         }
+        // Show an alert on basic message, this is useful for debugging.
+        app.agent!!.eventBus.subscribe<AgentEvents.BasicMessageEvent> {
+            lifecycleScope.launch(Dispatchers.Main) {
+                showAlert("${it.message}")
+            }
+        }
     }
 
     private fun showAlert(message: String) {
@@ -115,7 +122,14 @@ class WalletMainActivity : AppCompatActivity() {
             override fun onTick(millisUntilFinished: Long) {
                 if (app.walletOpened) {
                     subscribeEvents()
-                    progress.dismiss()
+                    // This causes a crash:
+                    // java.lang.IllegalArgumentException: View=DecorView@39d4aa3[Initializing agent] not attached to window manager
+                    // for now we just catch the exception
+                    try {
+                        progress.dismiss()
+                    } catch (e: Exception) {
+                        Log.d(TAG, e.message ?: "Unknown error")
+                    }
                     cancel()
                 }
             }

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/Agent.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/Agent.kt
@@ -3,6 +3,7 @@ package org.hyperledger.ariesframework.agent
 import android.content.Context
 import android.system.Os
 import org.hyperledger.ariesframework.EncryptedMessage
+import org.hyperledger.ariesframework.basicmessage.BasicMessageCommand
 import org.hyperledger.ariesframework.connection.ConnectionCommand
 import org.hyperledger.ariesframework.connection.ConnectionService
 import org.hyperledger.ariesframework.connection.repository.ConnectionRepository
@@ -43,6 +44,7 @@ class Agent(val context: Context, val agentConfig: AgentConfig) {
     val proofRepository = ProofRepository(this)
     val proofService = ProofService(this)
     val proofs = ProofCommand(this, dispatcher)
+    val basicMessages = BasicMessageCommand(this, dispatcher)
 
     private var _isInitialized = false
 

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/AgentEvents.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/AgentEvents.kt
@@ -12,4 +12,5 @@ sealed interface AgentEvents {
     class OutOfBandEvent(val record: OutOfBandRecord) : AgentEvents
     class CredentialEvent(val record: CredentialExchangeRecord) : AgentEvents
     class ProofEvent(val record: ProofExchangeRecord) : AgentEvents
+    class BasicMessageEvent(val message: String) : AgentEvents
 }

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/MessageSender.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/MessageSender.kt
@@ -5,6 +5,7 @@ import org.hyperledger.ariesframework.OutboundMessage
 import org.hyperledger.ariesframework.OutboundPackage
 import org.hyperledger.ariesframework.agent.decorators.ThreadDecorator
 import org.hyperledger.ariesframework.agent.decorators.TransportDecorator
+import org.hyperledger.ariesframework.connection.messages.TrustPingMessage
 import org.hyperledger.ariesframework.connection.models.ConnectionRole
 import org.hyperledger.ariesframework.connection.models.didauth.DidComm
 import org.hyperledger.ariesframework.connection.models.didauth.DidCommService
@@ -36,6 +37,14 @@ class MessageSender(val agent: Agent) {
 
     private fun decorateMessage(message: OutboundMessage): AgentMessage {
         val agentMessage = message.payload
+        // If the agent is initialized, and the message is a TrustPing message, set the transport to "all".
+        // This enables the agent to receive undelivered messages from the mediator.
+        // For this to work, requestResponse must be set to false. The mediator will only return queued
+        // messages if the trust ping message doesn't expect a response.
+        // This is tested with aca-py mediator 0.4.x
+        if(agent.isInitialized() && agentMessage.type == TrustPingMessage.type) {
+            agentMessage.transport = TransportDecorator("all")
+        }
         if (
             agentMessage.transport == null &&
             agentMessage.requestResponse() &&

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/MessageSender.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/MessageSender.kt
@@ -42,7 +42,7 @@ class MessageSender(val agent: Agent) {
         // For this to work, requestResponse must be set to false. The mediator will only return queued
         // messages if the trust ping message doesn't expect a response.
         // This is tested with aca-py mediator 0.4.x
-        if(agent.isInitialized() && agentMessage.type == TrustPingMessage.type) {
+        if (agent.isInitialized() && agentMessage.type == TrustPingMessage.type) {
             agentMessage.transport = TransportDecorator("all")
         }
         if (

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/BasicMessageCommand.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/BasicMessageCommand.kt
@@ -5,13 +5,6 @@ import org.hyperledger.ariesframework.agent.Dispatcher
 import org.hyperledger.ariesframework.agent.MessageSerializer
 import org.hyperledger.ariesframework.basicmessage.handlers.BasicMessageHandler
 import org.hyperledger.ariesframework.basicmessage.messages.BasicMessage
-import org.hyperledger.ariesframework.connection.handlers.ConnectionRequestHandler
-import org.hyperledger.ariesframework.connection.handlers.ConnectionResponseHandler
-import org.hyperledger.ariesframework.connection.handlers.TrustPingMessageHandler
-import org.hyperledger.ariesframework.connection.messages.ConnectionInvitationMessage
-import org.hyperledger.ariesframework.connection.messages.ConnectionRequestMessage
-import org.hyperledger.ariesframework.connection.messages.ConnectionResponseMessage
-import org.hyperledger.ariesframework.connection.messages.TrustPingMessage
 import org.slf4j.LoggerFactory
 
 class BasicMessageCommand(val agent: Agent, private val dispatcher: Dispatcher) {

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/BasicMessageCommand.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/BasicMessageCommand.kt
@@ -1,0 +1,32 @@
+package org.hyperledger.ariesframework.basicmessage
+
+import org.hyperledger.ariesframework.agent.Agent
+import org.hyperledger.ariesframework.agent.Dispatcher
+import org.hyperledger.ariesframework.agent.MessageSerializer
+import org.hyperledger.ariesframework.basicmessage.handlers.BasicMessageHandler
+import org.hyperledger.ariesframework.basicmessage.messages.BasicMessage
+import org.hyperledger.ariesframework.connection.handlers.ConnectionRequestHandler
+import org.hyperledger.ariesframework.connection.handlers.ConnectionResponseHandler
+import org.hyperledger.ariesframework.connection.handlers.TrustPingMessageHandler
+import org.hyperledger.ariesframework.connection.messages.ConnectionInvitationMessage
+import org.hyperledger.ariesframework.connection.messages.ConnectionRequestMessage
+import org.hyperledger.ariesframework.connection.messages.ConnectionResponseMessage
+import org.hyperledger.ariesframework.connection.messages.TrustPingMessage
+import org.slf4j.LoggerFactory
+
+class BasicMessageCommand(val agent: Agent, private val dispatcher: Dispatcher) {
+    private val logger = LoggerFactory.getLogger(BasicMessageCommand::class.java)
+
+    init {
+        registerHandlers(dispatcher)
+        registerMessages()
+    }
+
+    private fun registerHandlers(dispatcher: Dispatcher) {
+        dispatcher.registerHandler(BasicMessageHandler(agent))
+    }
+
+    private fun registerMessages() {
+        MessageSerializer.registerMessage(BasicMessage.type, BasicMessage::class)
+    }
+}

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/handlers/BasicMessageHandler.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/handlers/BasicMessageHandler.kt
@@ -12,7 +12,7 @@ class BasicMessageHandler(val agent: Agent) : MessageHandler {
 
     override suspend fun handle(messageContext: InboundMessageContext): OutboundMessage? {
         val message = messageContext.message as BasicMessage
-        agent.eventBus.publish(AgentEvents.BasicMessageEvent(message.content));
+        agent.eventBus.publish(AgentEvents.BasicMessageEvent(message.content))
         return null
     }
 }

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/handlers/BasicMessageHandler.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/handlers/BasicMessageHandler.kt
@@ -1,0 +1,18 @@
+package org.hyperledger.ariesframework.basicmessage.handlers
+
+import org.hyperledger.ariesframework.InboundMessageContext
+import org.hyperledger.ariesframework.OutboundMessage
+import org.hyperledger.ariesframework.agent.Agent
+import org.hyperledger.ariesframework.agent.AgentEvents
+import org.hyperledger.ariesframework.agent.MessageHandler
+import org.hyperledger.ariesframework.basicmessage.messages.BasicMessage
+
+class BasicMessageHandler(val agent: Agent) : MessageHandler {
+    override val messageType = BasicMessage.type
+
+    override suspend fun handle(messageContext: InboundMessageContext): OutboundMessage? {
+        val message = messageContext.message as BasicMessage
+        agent.eventBus.publish(AgentEvents.BasicMessageEvent(message.content));
+        return null
+    }
+}

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/messages/BasicMessage.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/messages/BasicMessage.kt
@@ -4,7 +4,8 @@ import kotlinx.serialization.Serializable
 import org.hyperledger.ariesframework.agent.AgentMessage
 
 @Serializable
-class BasicMessage(val content: String
+class BasicMessage(
+    val content: String,
 ) : AgentMessage(generateId(), BasicMessage.type) {
     companion object {
         const val type = "https://didcomm.org/basicmessage/1.0/message"

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/messages/BasicMessage.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/basicmessage/messages/BasicMessage.kt
@@ -1,0 +1,12 @@
+package org.hyperledger.ariesframework.basicmessage.messages
+
+import kotlinx.serialization.Serializable
+import org.hyperledger.ariesframework.agent.AgentMessage
+
+@Serializable
+class BasicMessage(val content: String
+) : AgentMessage(generateId(), BasicMessage.type) {
+    companion object {
+        const val type = "https://didcomm.org/basicmessage/1.0/message"
+    }
+}

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/routing/MediationRecipient.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/routing/MediationRecipient.kt
@@ -178,7 +178,10 @@ class MediationRecipient(private val agent: Agent, private val dispatcher: Dispa
             val message = OutboundMessage(BatchPickupMessage(10), mediatorConnection)
             agent.messageSender.send(message)
         } else if (agent.agentConfig.mediatorPickupStrategy == MediatorPickupStrategy.Implicit) {
-            val message = OutboundMessage(TrustPingMessage("pickup", true), mediatorConnection)
+            // For implicit pickup, responseRequested must be set to false.
+            // Since no response is requested, the mediator can respond with queued messages.
+            // Otherwise, it would respond with a trust ping response.
+            val message = OutboundMessage(TrustPingMessage("pickup", false), mediatorConnection)
             agent.messageSender.send(message, "ws")
         } else {
             throw RuntimeException("Unsupported mediator pickup strategy: ${agent.agentConfig.mediatorPickupStrategy}")


### PR DESCRIPTION
This PR fixes implicit pickup of queued messages from a mediator. It also adds support for basic messages which can aid in debugging as one can simply send them through the ACA-Py API.

It has been tested against a mediator running 0.4.x of ACA-Py and also against the Indicio Public Mediator. In both cases, earlier (before this PR) queued messages would not get picked up.

Now, they are correctly picked up.

Please see the following PR for work done in fixing ACA-Py routing which was also broken:
https://github.com/hyperledger/aries-cloudagent-python/pull/2536

With the above PR, and this PR, I have tested the mediator and also tested queued message delivery to this agent.