### PR TITLE
Implemented delete for Verifiable Credentials

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,12 +8,13 @@
     <application
         android:name=".WalletApp"
         android:usesCleartextTraffic="true"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="DataExtractionRules">
         <activity
             android:name=".CredentialListActivity"
             android:label="@string/title_credential_list"

--- a/app/src/main/java/org/hyperledger/ariesproject/CredentialDetailFragment.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/CredentialDetailFragment.kt
@@ -4,7 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.hyperledger.ariesproject.databinding.ActivityCredentialDetailBinding
 import org.hyperledger.ariesproject.databinding.CredentialDetailBinding
 import org.json.JSONObject
@@ -41,8 +45,36 @@ class CredentialDetailFragment : Fragment() {
                 val value = attrs.getString(key)
                 "$key: $value"
             }.joinToString("\n")
-        }
 
+            val activity = activity as CredentialDetailActivity
+            val credId = it.getString("referent")
+
+            // Bind the delete button to the delete action
+            binding.deleteCredentialButton.setOnClickListener {
+                // To prevent multiple clicks
+                binding.deleteCredentialButton.isEnabled = false
+                val builder = AlertDialog.Builder(activity)
+                builder.setTitle(R.string.title_delete_cred)
+                    .setMessage(R.string.title_delete_cred_detail)
+                    .setPositiveButton(R.string.ok) { dialog, which ->
+                        lifecycleScope.launch(Dispatchers.IO) {
+                            // Get application context from activity
+                            val app = activity.application as WalletApp
+                            app.agent!!.deleteCredential(credId)
+                            activity.runOnUiThread {
+                                dialog.dismiss()
+                                activity.finish()
+                            }
+                        }
+                    }
+                    .setNegativeButton(R.string.cancel) { dialog, which ->
+                        binding.deleteCredentialButton.isEnabled = true
+                        dialog.dismiss()
+                    }
+                    .create()
+                    .show()
+            }
+        }
         return rootView
     }
 

--- a/app/src/main/java/org/hyperledger/ariesproject/CredentialListActivity.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/CredentialListActivity.kt
@@ -28,7 +28,10 @@ class CredentialListActivity : AppCompatActivity() {
         binding.toolbar.title = title
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
 
+    override fun onResume() {
+        super.onResume()
         setupRecyclerView(binding.credentialList.credentialList)
     }
 

--- a/app/src/main/res/layout/credential_detail.xml
+++ b/app/src/main/res/layout/credential_detail.xml
@@ -1,10 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/credential_detail"
-    style="?android:attr/textAppearanceMedium"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="16dp"
-    android:textIsSelectable="true"
-    tools:context=".CredentialDetailFragment" />
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/credential_detail"
+        style="?android:attr/textAppearanceMedium"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp"
+        android:textIsSelectable="true"
+        tools:context=".CredentialDetailFragment" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/delete_credential_button"
+        android:text="@string/delete"
+        android:layout_margin="15dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,9 @@
     <string name="title_credential_list">Credentials</string>
     <string name="title_credential_detail">Credential detail</string>
     <string name="qrcode_guide">Scan a QR code and wait</string>
+    <string name="delete">Delete</string>
+    <string name="title_delete_cred">Delete Credential</string>
+    <string name="title_delete_cred_detail">Delete the selected credential?</string>
+    <string name="ok">Ok</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/Agent.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/Agent.kt
@@ -2,6 +2,7 @@ package org.hyperledger.ariesframework.agent
 
 import android.content.Context
 import android.system.Os
+import kotlinx.coroutines.future.await
 import org.hyperledger.ariesframework.EncryptedMessage
 import org.hyperledger.ariesframework.basicmessage.BasicMessageCommand
 import org.hyperledger.ariesframework.connection.ConnectionCommand
@@ -21,6 +22,7 @@ import org.hyperledger.ariesframework.proofs.repository.ProofRepository
 import org.hyperledger.ariesframework.routing.MediationRecipient
 import org.hyperledger.ariesframework.storage.DidCommMessageRepository
 import org.hyperledger.ariesframework.wallet.Wallet
+import org.hyperledger.indy.sdk.anoncreds.Anoncreds
 
 class Agent(val context: Context, val agentConfig: AgentConfig) {
     val wallet: Wallet = Wallet(this)
@@ -104,6 +106,23 @@ class Agent(val context: Context, val agentConfig: AgentConfig) {
         }
         wallet.delete()
         ledgerService.delete()
+    }
+
+    /**
+     * Remove a specified credential from the wallet.
+     */
+    suspend fun deleteCredential(credentialId: String) {
+        var creds = credentialRepository.getAll()
+
+        creds.forEach {
+            val record = it
+            it.credentials.forEach {
+                if (it.credentialRecordId == credentialId) {
+                    credentialRepository.delete(record)
+                    Anoncreds.proverDeleteCredential(wallet.indyWallet, credentialId).await()
+                }
+            }
+        }
     }
 
     suspend fun receiveMessage(encryptedMessage: EncryptedMessage) {

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/Agent.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/agent/Agent.kt
@@ -112,17 +112,7 @@ class Agent(val context: Context, val agentConfig: AgentConfig) {
      * Remove a specified credential from the wallet.
      */
     suspend fun deleteCredential(credentialId: String) {
-        var creds = credentialRepository.getAll()
-
-        creds.forEach {
-            val record = it
-            it.credentials.forEach {
-                if (it.credentialRecordId == credentialId) {
-                    credentialRepository.delete(record)
-                    Anoncreds.proverDeleteCredential(wallet.indyWallet, credentialId).await()
-                }
-            }
-        }
+        Anoncreds.proverDeleteCredential(wallet.indyWallet, credentialId).await()
     }
 
     suspend fun receiveMessage(encryptedMessage: EncryptedMessage) {

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialService.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialService.kt
@@ -15,6 +15,7 @@ import org.hyperledger.ariesframework.agent.MessageSerializer
 import org.hyperledger.ariesframework.agent.decorators.Attachment
 import org.hyperledger.ariesframework.agent.decorators.ThreadDecorator
 import org.hyperledger.ariesframework.credentials.messages.CredentialAckMessage
+import org.hyperledger.ariesframework.credentials.messages.CredentialProblemReportMessage
 import org.hyperledger.ariesframework.credentials.messages.IssueCredentialMessage
 import org.hyperledger.ariesframework.credentials.messages.OfferCredentialMessage
 import org.hyperledger.ariesframework.credentials.messages.ProposeCredentialMessage
@@ -345,6 +346,22 @@ class CredentialService(val agent: Agent) {
         updateState(credentialRecord, CredentialState.Done)
 
         return CredentialAckMessage(credentialRecord.threadId, AckStatus.OK)
+    }
+
+    /**
+     * Create an ``CredentialProblemReportMessage`` as response to a received offer.
+     *
+     * @param options options for the problem report message.
+     * @return credential problem report message.
+     */
+    suspend fun createProblemReport(options: AcceptOfferOptions): CredentialProblemReportMessage {
+        var credentialRecord = credentialRepository.getById(options.credentialRecordId)
+        credentialRecord.assertProtocolVersion("v1")
+        credentialRecord.assertState(CredentialState.OfferReceived)
+
+        updateState(credentialRecord, CredentialState.Declined)
+
+        return CredentialProblemReportMessage(credentialRecord.threadId)
     }
 
     /**

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialService.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialService.kt
@@ -354,7 +354,7 @@ class CredentialService(val agent: Agent) {
      * @param options options for the problem report message.
      * @return credential problem report message.
      */
-    suspend fun createProblemReport(options: AcceptOfferOptions): CredentialProblemReportMessage {
+    suspend fun createOfferDeclinedProblemReport(options: AcceptOfferOptions): CredentialProblemReportMessage {
         var credentialRecord = credentialRepository.getById(options.credentialRecordId)
         credentialRecord.assertProtocolVersion("v1")
         credentialRecord.assertState(CredentialState.OfferReceived)

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialsCommand.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialsCommand.kt
@@ -11,6 +11,7 @@ import org.hyperledger.ariesframework.credentials.handlers.IssueCredentialHandle
 import org.hyperledger.ariesframework.credentials.handlers.OfferCredentialHandler
 import org.hyperledger.ariesframework.credentials.handlers.RequestCredentialHandler
 import org.hyperledger.ariesframework.credentials.messages.CredentialAckMessage
+import org.hyperledger.ariesframework.credentials.messages.CredentialProblemReportMessage
 import org.hyperledger.ariesframework.credentials.messages.IssueCredentialMessage
 import org.hyperledger.ariesframework.credentials.messages.OfferCredentialMessage
 import org.hyperledger.ariesframework.credentials.messages.ProposeCredentialMessage
@@ -20,7 +21,6 @@ import org.hyperledger.ariesframework.credentials.models.AcceptOfferOptions
 import org.hyperledger.ariesframework.credentials.models.AcceptRequestOptions
 import org.hyperledger.ariesframework.credentials.models.CreateOfferOptions
 import org.hyperledger.ariesframework.credentials.models.CreateProposalOptions
-import org.hyperledger.ariesframework.credentials.models.CredentialState
 import org.hyperledger.ariesframework.credentials.repository.CredentialExchangeRecord
 import org.slf4j.LoggerFactory
 
@@ -45,6 +45,7 @@ class CredentialsCommand(val agent: Agent, private val dispatcher: Dispatcher) {
         MessageSerializer.registerMessage(OfferCredentialMessage.type, OfferCredentialMessage::class)
         MessageSerializer.registerMessage(ProposeCredentialMessage.type, ProposeCredentialMessage::class)
         MessageSerializer.registerMessage(RequestCredentialMessage.type, RequestCredentialMessage::class)
+        MessageSerializer.registerMessage(CredentialProblemReportMessage.type, CredentialProblemReportMessage::class)
     }
 
     /**
@@ -93,16 +94,16 @@ class CredentialsCommand(val agent: Agent, private val dispatcher: Dispatcher) {
     }
 
     /**
-     * Declines an offer as holder
+     * Declines a credential offer as holder (by sending a problem report message) to the connection
      *
-     * @param credentialRecordId the id of the credential to be declined.
-     * @return credential record that was declined.
+     * @param options options to decline the offer.
+     * @return credential record associated with the declined credential.
      */
-    suspend fun declineOffer(credentialRecordId: String): CredentialExchangeRecord {
-        var credentialRecord = agent.credentialRepository.getById(credentialRecordId)
-        credentialRecord.assertState(CredentialState.OfferReceived)
-        agent.credentialService.updateState(credentialRecord, CredentialState.Declined)
-
+    suspend fun declineOffer(options: AcceptOfferOptions): CredentialExchangeRecord {
+        val message = agent.credentialService.createProblemReport(options)
+        var credentialRecord = agent.credentialRepository.getById(options.credentialRecordId)
+        val connection = agent.connectionRepository.getById(credentialRecord.connectionId)
+        agent.messageSender.send(OutboundMessage(message, connection))
         return credentialRecord
     }
 

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialsCommand.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/CredentialsCommand.kt
@@ -100,7 +100,7 @@ class CredentialsCommand(val agent: Agent, private val dispatcher: Dispatcher) {
      * @return credential record associated with the declined credential.
      */
     suspend fun declineOffer(options: AcceptOfferOptions): CredentialExchangeRecord {
-        val message = agent.credentialService.createProblemReport(options)
+        val message = agent.credentialService.createOfferDeclinedProblemReport(options)
         var credentialRecord = agent.credentialRepository.getById(options.credentialRecordId)
         val connection = agent.connectionRepository.getById(credentialRecord.connectionId)
         agent.messageSender.send(OutboundMessage(message, connection))

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/messages/CredentialProblemReportMessage.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/credentials/messages/CredentialProblemReportMessage.kt
@@ -1,0 +1,23 @@
+package org.hyperledger.ariesframework.credentials.messages
+import kotlinx.serialization.Serializable
+import org.hyperledger.ariesframework.agent.BaseProblemReportMessage
+import org.hyperledger.ariesframework.agent.DescriptionOptions
+import org.hyperledger.ariesframework.agent.decorators.ThreadDecorator
+
+@Serializable
+class CredentialProblemReportMessage private constructor() : BaseProblemReportMessage(
+    // See: https://github.com/hyperledger/aries-cloudagent-python/blob/main/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_problem_report.py // ktlint-disable max-line-length
+    DescriptionOptions(
+        "Issuance abandoned",
+        "issuance-abandoned",
+    ),
+    null,
+) {
+    constructor(threadId: String) : this() {
+        thread = ThreadDecorator(threadId)
+        type = CredentialProblemReportMessage.type
+    }
+    companion object {
+        const val type = "https://didcomm.org/issue-credential/1.0/problem-report"
+    }
+}

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofCommand.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofCommand.kt
@@ -108,7 +108,7 @@ class ProofCommand(val agent: Agent, private val dispatcher: Dispatcher) {
         proofRecordId: String,
     ): ProofExchangeRecord {
         val record = agent.proofRepository.getById(proofRecordId)
-        val (message, proofRecord) = agent.proofService.createProblemReport(record)
+        val (message, proofRecord) = agent.proofService.createPresentationDeclinedProblemReport(record)
 
         val connection = agent.connectionRepository.getById(record.connectionId)
         agent.messageSender.send(OutboundMessage(message, connection))

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofCommand.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofCommand.kt
@@ -11,6 +11,7 @@ import org.hyperledger.ariesframework.proofs.handlers.PresentationHandler
 import org.hyperledger.ariesframework.proofs.handlers.RequestPresentationHandler
 import org.hyperledger.ariesframework.proofs.messages.PresentationAckMessage
 import org.hyperledger.ariesframework.proofs.messages.PresentationMessage
+import org.hyperledger.ariesframework.proofs.messages.PresentationProblemReportMessage
 import org.hyperledger.ariesframework.proofs.messages.RequestPresentationMessage
 import org.hyperledger.ariesframework.proofs.models.AutoAcceptProof
 import org.hyperledger.ariesframework.proofs.models.ProofRequest
@@ -37,6 +38,7 @@ class ProofCommand(val agent: Agent, private val dispatcher: Dispatcher) {
         MessageSerializer.registerMessage(RequestPresentationMessage.type, RequestPresentationMessage::class)
         MessageSerializer.registerMessage(PresentationMessage.type, PresentationMessage::class)
         MessageSerializer.registerMessage(PresentationAckMessage.type, PresentationAckMessage::class)
+        MessageSerializer.registerMessage(PresentationProblemReportMessage.type, PresentationProblemReportMessage::class)
     }
 
     /**
@@ -88,6 +90,25 @@ class ProofCommand(val agent: Agent, private val dispatcher: Dispatcher) {
             requestedCredentials,
             comment,
         )
+
+        val connection = agent.connectionRepository.getById(record.connectionId)
+        agent.messageSender.send(OutboundMessage(message, connection))
+
+        return proofRecord
+    }
+
+    /**
+     * Decline a presentation request as prover (by sending a problem report message) to the connection
+     * associated with the proof record.
+     *
+     * @param proofRecordId the id of the proof record for which to decline the request.
+     * @return proof record associated with the sent presentation request message.
+     */
+    suspend fun declineRequest(
+        proofRecordId: String,
+    ): ProofExchangeRecord {
+        val record = agent.proofRepository.getById(proofRecordId)
+        val (message, proofRecord) = agent.proofService.createProblemReport(record)
 
         val connection = agent.connectionRepository.getById(record.connectionId)
         agent.messageSender.send(OutboundMessage(message, connection))

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofService.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofService.kt
@@ -19,6 +19,7 @@ import org.hyperledger.ariesframework.agent.decorators.ThreadDecorator
 import org.hyperledger.ariesframework.connection.repository.ConnectionRecord
 import org.hyperledger.ariesframework.proofs.messages.PresentationAckMessage
 import org.hyperledger.ariesframework.proofs.messages.PresentationMessage
+import org.hyperledger.ariesframework.proofs.messages.PresentationProblemReportMessage
 import org.hyperledger.ariesframework.proofs.messages.RequestPresentationMessage
 import org.hyperledger.ariesframework.proofs.models.AutoAcceptProof
 import org.hyperledger.ariesframework.proofs.models.CredentialsForProof
@@ -187,6 +188,21 @@ class ProofService(val agent: Agent) {
         updateState(proofRecord, ProofState.Done)
 
         return Pair(ackMessage, proofRecord)
+    }
+
+    /**
+     * Create a ``PresentationProblemReport`` as response to a received presentation request.
+     *
+     * @param proofRecord the proof record for which to create the presentation acknowledgement.
+     * @return the presentation problem report message and an associated proof record.
+     */
+    suspend fun createProblemReport(proofRecord: ProofExchangeRecord): Pair<PresentationProblemReportMessage, ProofExchangeRecord> {
+        proofRecord.assertState(ProofState.RequestReceived)
+
+        val probMessage = PresentationProblemReportMessage(proofRecord.threadId)
+        updateState(proofRecord, ProofState.Declined)
+
+        return Pair(probMessage, proofRecord)
     }
 
     /**

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofService.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/ProofService.kt
@@ -196,7 +196,7 @@ class ProofService(val agent: Agent) {
      * @param proofRecord the proof record for which to create the presentation acknowledgement.
      * @return the presentation problem report message and an associated proof record.
      */
-    suspend fun createProblemReport(proofRecord: ProofExchangeRecord): Pair<PresentationProblemReportMessage, ProofExchangeRecord> {
+    suspend fun createPresentationDeclinedProblemReport(proofRecord: ProofExchangeRecord): Pair<PresentationProblemReportMessage, ProofExchangeRecord> {
         proofRecord.assertState(ProofState.RequestReceived)
 
         val probMessage = PresentationProblemReportMessage(proofRecord.threadId)

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/messages/PresentationProblemReportMessage.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/messages/PresentationProblemReportMessage.kt
@@ -1,0 +1,24 @@
+package org.hyperledger.ariesframework.proofs.messages
+
+import kotlinx.serialization.Serializable
+import org.hyperledger.ariesframework.agent.BaseProblemReportMessage
+import org.hyperledger.ariesframework.agent.DescriptionOptions
+import org.hyperledger.ariesframework.agent.decorators.ThreadDecorator
+
+@Serializable
+class PresentationProblemReportMessage private constructor() : BaseProblemReportMessage(
+    // See: https://github.com/hyperledger/aries-cloudagent-python/blob/main/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_problem_report.py // ktlint-disable max-line-length
+    DescriptionOptions(
+        "Proof abandoned",
+        "abandoned",
+    ),
+    null,
+) {
+    constructor(threadId: String) : this() {
+        thread = ThreadDecorator(threadId)
+        type = PresentationProblemReportMessage.type
+    }
+    companion object {
+        const val type = "https://didcomm.org/present-proof/1.0/problem-report"
+    }
+}


### PR DESCRIPTION
During development it is useful to be able to delete credentials.

This PR implements a `Delete` button on the `Credential Detail` screen.

Additionally, the manifest file is changed to `android:allowBackup="false"`. This is so that the credentials are removed when the app is uninstalled.

Otherwise, they persist and the backed up version can differ from the state of the wallet even when credentials are deleted.

It is useful during development to have the credentials removed upon app uninstall.