### PR TITLE
Fix type casting error when using 'as' keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Subscribe to agent.eventBus to receive events from the agent and use `agent.cred
 ```kotlin
     private fun subscribeEvents() {
         val app = application as WalletApp
-        app.agent!!.eventBus.subscribe<AgentEvents.CredentialEvent> {
+        app.agent.eventBus.subscribe<AgentEvents.CredentialEvent> {
             lifecycleScope.launch(Dispatchers.Main) {
                 if (it.record.state == CredentialState.OfferReceived) {
                     getCredential(it.record.id)
@@ -126,7 +126,7 @@ Subscribe to agent.eventBus to receive events from the agent and use `agent.cred
                 }
             }
         }
-        app.agent!!.eventBus.subscribe<AgentEvents.ProofEvent> {
+        app.agent.eventBus.subscribe<AgentEvents.ProofEvent> {
             lifecycleScope.launch(Dispatchers.Main) {
                 if (it.record.state == ProofState.RequestReceived) {
                     sendProof(it.record.id)
@@ -141,7 +141,7 @@ Subscribe to agent.eventBus to receive events from the agent and use `agent.cred
         val app = application as WalletApp
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                app.agent!!.credentials.acceptOffer(
+                app.agent.credentials.acceptOffer(
                     AcceptOfferOptions(credentialRecordId = id, autoAcceptCredential = AutoAcceptCredential.Always),
                 )
             } catch (e: Exception) {
@@ -156,9 +156,9 @@ Subscribe to agent.eventBus to receive events from the agent and use `agent.cred
         val app = application as WalletApp
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                val retrievedCredentials = app.agent!!.proofs.getRequestedCredentialsForProofRequest(id)
-                val requestedCredentials = app.agent!!.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials)
-                app.agent!!.proofs.acceptRequest(id, requestedCredentials)
+                val retrievedCredentials = app.agent.proofs.getRequestedCredentialsForProofRequest(id)
+                val requestedCredentials = app.agent.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials)
+                app.agent.proofs.acceptRequest(id, requestedCredentials)
             } catch (e: Exception) {
                 lifecycleScope.launch(Dispatchers.Main) {
                     showAlert("Failed to present proof.")

--- a/app/src/main/java/org/hyperledger/ariesproject/CredentialDetailFragment.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/CredentialDetailFragment.kt
@@ -60,7 +60,7 @@ class CredentialDetailFragment : Fragment() {
                         lifecycleScope.launch(Dispatchers.IO) {
                             // Get application context from activity
                             val app = activity.application as WalletApp
-                            app.agent!!.deleteCredential(credId)
+                            app.agent.deleteCredential(credId)
                             activity.runOnUiThread {
                                 dialog.dismiss()
                                 activity.finish()

--- a/app/src/main/java/org/hyperledger/ariesproject/CredentialListActivity.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/CredentialListActivity.kt
@@ -46,7 +46,7 @@ class CredentialListActivity : AppCompatActivity() {
 
     private fun setupRecyclerView(recyclerView: RecyclerView) {
         val app = application as WalletApp
-        val credentials = Anoncreds.proverGetCredentials(app.agent!!.wallet.indyWallet, "{}").get()
+        val credentials = Anoncreds.proverGetCredentials(app.agent.wallet.indyWallet, "{}").get()
         recyclerView.adapter = SimpleItemRecyclerViewAdapter(this, JSONArray(credentials))
     }
 

--- a/app/src/main/java/org/hyperledger/ariesproject/WalletApp.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/WalletApp.kt
@@ -18,7 +18,7 @@ const val PREFERENCE_NAME = "aries-framework-kotlin-sample"
 const val genesisPath = "bcovrin-genesis.txn"
 
 class WalletApp : Application() {
-    var agent: Agent? = null
+    lateinit var agent: Agent
     var walletOpened: Boolean = false
 
     private fun copyResourceFile(resource: String) {
@@ -51,7 +51,7 @@ class WalletApp : Application() {
             autoAcceptProof = AutoAcceptProof.Never,
         )
         agent = Agent(applicationContext, config)
-        agent!!.initialize()
+        agent.initialize()
 
         walletOpened = true
         Log.d("demo", "Agent initialized")

--- a/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
@@ -48,7 +48,7 @@ class WalletMainActivity : AppCompatActivity() {
             if (invitation.isNotEmpty()) {
                 val app = application as WalletApp
                 lifecycleScope.launch(Dispatchers.Main) {
-                    val (_, connection) = app.agent!!.oob.receiveInvitationFromUrl(invitation)
+                    val (_, connection) = app.agent.oob.receiveInvitationFromUrl(invitation)
                     showAlert("Connected to ${connection?.theirLabel ?: "unknown agent"}")
                 }
             }
@@ -62,7 +62,7 @@ class WalletMainActivity : AppCompatActivity() {
 
     private fun subscribeEvents() {
         val app = application as WalletApp
-        app.agent!!.eventBus.subscribe<AgentEvents.CredentialEvent> {
+        app.agent.eventBus.subscribe<AgentEvents.CredentialEvent> {
             lifecycleScope.launch(Dispatchers.Main) {
                 if (it.record.state == CredentialState.OfferReceived) {
                     runOnConfirm("Accept credential?", action = {
@@ -76,7 +76,7 @@ class WalletMainActivity : AppCompatActivity() {
                 }
             }
         }
-        app.agent!!.eventBus.subscribe<AgentEvents.ProofEvent> {
+        app.agent.eventBus.subscribe<AgentEvents.ProofEvent> {
             lifecycleScope.launch(Dispatchers.Main) {
                 if (it.record.state == ProofState.RequestReceived) {
                     runOnConfirm("Accept proof request?", action = {
@@ -91,7 +91,7 @@ class WalletMainActivity : AppCompatActivity() {
             }
         }
         // Show an alert on basic message, this is useful for debugging.
-        app.agent!!.eventBus.subscribe<AgentEvents.BasicMessageEvent> {
+        app.agent.eventBus.subscribe<AgentEvents.BasicMessageEvent> {
             lifecycleScope.launch(Dispatchers.Main) {
                 showAlert("${it.message}")
             }
@@ -157,7 +157,7 @@ class WalletMainActivity : AppCompatActivity() {
 
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                app.agent!!.credentials.declineOffer(
+                app.agent.credentials.declineOffer(
                     AcceptOfferOptions(
                         credentialRecordId = id,
                         autoAcceptCredential = AutoAcceptCredential.Never,
@@ -177,7 +177,7 @@ class WalletMainActivity : AppCompatActivity() {
 
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                app.agent!!.proofs.declineRequest(id)
+                app.agent.proofs.declineRequest(id)
             } catch (e: Exception) {
                 lifecycleScope.launch(Dispatchers.Main) {
                     Log.d("demo", e.localizedMessage)
@@ -195,7 +195,7 @@ class WalletMainActivity : AppCompatActivity() {
 
         val job = lifecycleScope.launch(Dispatchers.IO) {
             try {
-                app.agent!!.credentials.acceptOffer(
+                app.agent.credentials.acceptOffer(
                     AcceptOfferOptions(credentialRecordId = id, autoAcceptCredential = AutoAcceptCredential.Always),
                 )
             } catch (e: Exception) {
@@ -222,9 +222,9 @@ class WalletMainActivity : AppCompatActivity() {
 
         val job = lifecycleScope.launch(Dispatchers.IO) {
             try {
-                val retrievedCredentials = app.agent!!.proofs.getRequestedCredentialsForProofRequest(id)
-                val requestedCredentials = app.agent!!.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials)
-                app.agent!!.proofs.acceptRequest(id, requestedCredentials)
+                val retrievedCredentials = app.agent.proofs.getRequestedCredentialsForProofRequest(id)
+                val requestedCredentials = app.agent.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials)
+                app.agent.proofs.acceptRequest(id, requestedCredentials)
             } catch (e: Exception) {
                 lifecycleScope.launch(Dispatchers.Main) {
                     Log.d("demo", e.localizedMessage)
@@ -249,7 +249,7 @@ class WalletMainActivity : AppCompatActivity() {
                 try {
                     val qrcodeData = data!!.getStringExtra("qrcode")
                     Log.d("demo", "Scanned code: $qrcodeData")
-                    val (_, connection) = app.agent!!.oob.receiveInvitationFromUrl(qrcodeData!!)
+                    val (_, connection) = app.agent.oob.receiveInvitationFromUrl(qrcodeData!!)
                     showAlert("Connected to ${connection?.theirLabel ?: "unknown agent"}")
                 } catch (e: Exception) {
                     Log.d("demo", e.localizedMessage)

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/ledger/LedgerService.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/ledger/LedgerService.kt
@@ -115,22 +115,22 @@ class LedgerService(val agent: Agent) {
 
     suspend fun getRevocationRegistryDelta(
         id: String,
-        to: Int = (System.currentTimeMillis() / 1000L) as Int,
+        to: Int = (System.currentTimeMillis() / 1000L).toInt(),
         from: Int = 0,
     ): Pair<String, Int> {
         logger.debug("Get RevocationRegistryDelta with id: $id")
-        val request = Ledger.buildGetRevocRegDeltaRequest(null, id, from as Long, to as Long).await()
+        val request = Ledger.buildGetRevocRegDeltaRequest(null, id, from.toLong(), to.toLong()).await()
         val response = submitReadRequest(request!!)
         val revocationRegistryDelta = Ledger.parseGetRevocRegDeltaResponse(response).await()
-        return Pair(revocationRegistryDelta.objectJson, revocationRegistryDelta.timestamp as Int)
+        return Pair(revocationRegistryDelta.objectJson, revocationRegistryDelta.timestamp.toInt())
     }
 
     suspend fun getRevocationRegistry(id: String, timestamp: Int): Pair<String, Int> {
         logger.debug("Get RevocationRegistry with id: $id, timestamp: $timestamp")
-        val request = Ledger.buildGetRevocRegRequest(null, id, timestamp as Long).await()
+        val request = Ledger.buildGetRevocRegRequest(null, id, timestamp.toLong()).await()
         val response = submitReadRequest(request!!)
         val revocationRegistry = Ledger.parseGetRevocRegResponse(response).await()
-        return Pair(revocationRegistry.objectJson, revocationRegistry.timestamp as Int)
+        return Pair(revocationRegistry.objectJson, revocationRegistry.timestamp.toInt())
     }
 
     private fun validateResponse(response: String) {

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/RevocationService.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/proofs/RevocationService.kt
@@ -111,7 +111,7 @@ class RevocationService(val agent: Agent) {
                     tailsReader.blobStorageReaderHandle,
                     revocationRegistryDefinition,
                     revocationRegistryDelta,
-                    deltaTimestamp as Long,
+                    deltaTimestamp.toLong(),
                     credentialRevocationId,
                 ).await()
                 val revocationState = Json.decodeFromString<JsonObject>(revocationStateJson)


### PR DESCRIPTION
1. I changed the `var agent` property to use `lateinit` so it can be used without `!!`.

2. I ran into the following errors, and fixed this type casting by calling the `toInt()` and `toLong()` methods.

```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
    at org.hyperledger.ariesframework.ledger.LedgerService.getRevocationRegistryDelta(LedgerService.kt:122)
    at org.hyperledger.ariesframework.proofs.RevocationService.getRevocationStatus(RevocationService.kt:67)
    at org.hyperledger.ariesframework.proofs.ProofService.getRevocationStatusForRequestedItem(ProofService.kt:344)
    at org.hyperledger.ariesframework.proofs.ProofService$getRequestedCredentialsForProofRequest$lambda$2$$inlined$concurrentMap$1.invokeSuspend(ConcurrentTransform.kt:37)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
```

```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
    at org.hyperledger.ariesframework.proofs.RevocationService$createRevocationState$$inlined$concurrentForEach$1.invokeSuspend(ConcurrentTransform.kt:60)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
```