### PR TITLE
Fix crash during pickup if network is turned off

### DIFF
--- a/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
@@ -51,8 +51,7 @@ class WalletMainActivity : AppCompatActivity() {
                     try {
                         val (_, connection) = app.agent.oob.receiveInvitationFromUrl(invitation)
                         showAlert("Connected to ${connection?.theirLabel ?: "unknown agent"}")
-                    }
-                    catch (e: Exception) {
+                    } catch (e: Exception) {
                         showAlert("Unable to connect, please check your network connection")
                     }
                 }

--- a/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
+++ b/app/src/main/java/org/hyperledger/ariesproject/WalletMainActivity.kt
@@ -48,8 +48,13 @@ class WalletMainActivity : AppCompatActivity() {
             if (invitation.isNotEmpty()) {
                 val app = application as WalletApp
                 lifecycleScope.launch(Dispatchers.Main) {
-                    val (_, connection) = app.agent.oob.receiveInvitationFromUrl(invitation)
-                    showAlert("Connected to ${connection?.theirLabel ?: "unknown agent"}")
+                    try {
+                        val (_, connection) = app.agent.oob.receiveInvitationFromUrl(invitation)
+                        showAlert("Connected to ${connection?.theirLabel ?: "unknown agent"}")
+                    }
+                    catch (e: Exception) {
+                        showAlert("Unable to connect, please check your network connection")
+                    }
                 }
             }
             true

--- a/ariesframework/src/main/java/org/hyperledger/ariesframework/routing/MediationRecipient.kt
+++ b/ariesframework/src/main/java/org/hyperledger/ariesframework/routing/MediationRecipient.kt
@@ -179,8 +179,6 @@ class MediationRecipient(private val agent: Agent, private val dispatcher: Dispa
             try {
                 agent.messageSender.send(message)
             } catch (e: Exception) {
-                // We catch the exception here because if there is a network failure
-                // the framework will simply retry picking up the messages later.
                 logger.debug("Pickup messages failed with the following error: ${e.message}")
             }
         } else if (agent.agentConfig.mediatorPickupStrategy == MediatorPickupStrategy.Implicit) {
@@ -189,8 +187,6 @@ class MediationRecipient(private val agent: Agent, private val dispatcher: Dispa
             // Otherwise, it would respond with a trust ping response.
             val message = OutboundMessage(TrustPingMessage("pickup", false), mediatorConnection)
             try {
-                // We catch the exception here because if there is a network failure
-                // the framework will simply retry picking up the messages later.
                 agent.messageSender.send(message, "ws")
             } catch (e: Exception) {
                 logger.debug("Pickup messages failed with the following error: ${e.message}")


### PR DESCRIPTION
In the current implementation, if the network is turned off, pickup of messages causes an application crash.

This PR fixes this by silently ignoring crashes during a pickup (as pickup will be retried at the polling frequency specified).

Also, there was no exception handling during the establishment of a connection (in the `WalletMainActivity`), this has been fixed too.

@conanoc / @DrumRobot request you to review this and merge. 